### PR TITLE
Fix: Configure Vercel deployment settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build",
+    "build": "npx prisma generate && next build",
     "start": "next start",
     "lint": "next lint"
   },

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "framework": "nextjs",
+  "buildCommand": "next build",
+  "outputDirectory": ".next",
+  "scripts": {
+    "build": "npx prisma generate && next build"
+  }
+}


### PR DESCRIPTION
I added a `vercel.json` file to explicitly define the framework, build command, and output directory for Vercel. This helps ensure Vercel correctly identifies and builds your Next.js project.

I also updated the build script in `package.json` to include `npx prisma generate` before `next build` as a best practice to ensure the Prisma client is generated during the build process.